### PR TITLE
Windows problems

### DIFF
--- a/lua/csharpls_extended.lua
+++ b/lua/csharpls_extended.lua
@@ -129,7 +129,7 @@ M.handle_locations = function(locations, offset_encoding)
 
     if not vim.tbl_isempty(fetched) then
         if #locations > 1 then
-            utils.set_qflist_locations(locations)
+            utils.set_qflist_locations(locations, offset_encoding)
             vim.api.nvim_command("copen")
             return true
         else

--- a/lua/csharpls_extended/utils.lua
+++ b/lua/csharpls_extended/utils.lua
@@ -42,6 +42,9 @@ U.get_or_create_buf = function(name)
         else
             if bufname == name then
                 return buf
+            -- Match a bufname like C:\System.Console
+            elseif string.find(string.gsub(bufname, "%u:\\", "/"), name) then
+                return buf
             end
         end
     end
@@ -51,8 +54,8 @@ U.get_or_create_buf = function(name)
     return bufnr
 end
 
-U.set_qflist_locations = function(locations)
-    local items = vim.lsp.util.locations_to_items(locations)
+U.set_qflist_locations = function(locations, offset_encoding)
+    local items = vim.lsp.util.locations_to_items(locations, offset_encoding)
     vim.fn.setqflist({}, " ", {
         title = "Language Server",
         items = items,


### PR DESCRIPTION
Sometimes windows seems to put the letter drive name (e.g. `C:`) at the beginning of the path. This caused `get_or_create_buf` to not return the existing buffer number and instead it tried to create a new one.