### PR TITLE
docs: update type definition capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # csharpls-extended-lsp.nvim
 
-Extended `textDocument/definition` handler that handles assembly/decompilation
+Extended `textDocument/definition` and `textDocument/typeDefinition` handler that handles assembly/decompilation
 loading for `$metadata$` documents.
 
 ## How it works
@@ -80,7 +80,7 @@ If using `lspconfig` this can be done like this:
 
 First configure omnisharp as per [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#omnisharp).
 
-Then to that config add `handlers` with custom handler from this plugin.
+Then to that config add `handlers` with custom handlers from this plugin.
 
 ```lua
 local pid = vim.fn.getpid()
@@ -91,6 +91,7 @@ local pid = vim.fn.getpid()
 local config = {
   handlers = {
     ["textDocument/definition"] = require('csharpls_extended').handler,
+    ["textDocument/typeDefinition"] = require('csharpls_extended').handler,
   },
   cmd = { csharpls },
   -- rest of your settings


### PR DESCRIPTION
You can jump to the definitions of decompiled types in csharp LS now: https://github.com/razzmatazz/csharp-language-server/pull/123 

so in preparation for that feature to be released, we should update the README here. I tested this behavior for disassembled code on 0.10.0, and it seems to work the same way as definition