### PR TITLE
docs: callout telescope compability

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ local config = {
 require'lspconfig'.csharp_ls.setup(config)
 ```
 
+*Note: Avoid using `telescope.lsp_definitions` and use `vim.lsp.buf.definition` until [this PR](https://github.com/Decodetalkers/csharpls-extended-lsp.nvim/pull/11) is merged in.
+
 ### For Neovim 0.5.1
 
 Due to the fact that in 0.5.1 request params are not available is handler


### PR DESCRIPTION
Based on https://github.com/Decodetalkers/csharpls-extended-lsp.nvim/issues/7, and the current attention by kickstart's configuration [which uses Telescope for viewing definitions](https://github.com/nvim-lua/kickstart.nvim/blob/master/init.lua#L466), I suggest calling the compatibility issue in the `readme,md` to potential users and also mention the related PR which solves the issue https://github.com/Decodetalkers/csharpls-extended-lsp.nvim/pull/11.