### PR TITLE
Fix check nvim version

### DIFF
--- a/lua/csharpls_extended.lua
+++ b/lua/csharpls_extended.lua
@@ -169,7 +169,7 @@ M.handle_locations = function(locations, offset_encoding)
             vim.api.nvim_command("copen")
             return true
         else
-            if vim.fn.has('nvim-0.11') ~= 0 then
+            if vim.fn.has('nvim-0.11') == 1 then
                 vim.lsp.util.show_document(locations[0], offset_encoding, { focus = true })
             else
                 -- NOTE: for nvim < 0.11
@@ -198,7 +198,7 @@ M.lsp_definitions = function()
     local client = M.get_csharpls_client()
     if client then
         local params
-        if vim.fn.has('nvim-0.11') then
+        if vim.fn.has('nvim-0.11') == 1 then
             params = vim.lsp.util.make_position_params(0, 'utf-8')
         else
             params = vim.lsp.util.make_position_params()

--- a/lua/csharpls_extended.lua
+++ b/lua/csharpls_extended.lua
@@ -169,7 +169,7 @@ M.handle_locations = function(locations, offset_encoding)
             vim.api.nvim_command("copen")
             return true
         else
-            if vim.fn.has('nvim-0.11') then
+            if vim.fn.has('nvim-0.11') ~= 0 then
                 vim.lsp.util.show_document(locations[0], offset_encoding, { focus = true })
             else
                 -- NOTE: for nvim < 0.11

--- a/lua/telescope/_extensions/csharpls_definition.lua
+++ b/lua/telescope/_extensions/csharpls_definition.lua
@@ -20,7 +20,7 @@ M.telescope_handle_location = function(locations, offset_encoding, opts)
         return
     end
     if #locations == 1 then
-        if vim.fn.has('nvim-0.11') then
+        if vim.fn.has('nvim-0.11') == 1 then
             vim.lsp.util.show_document(fetched[1], offset_encoding, { focus = true })
         else
             vim.lsp.util.jump_to_location(fetched[1], offset_encoding)
@@ -56,7 +56,7 @@ M.csharpls_telescope = function(opts)
     local client = csharpls_extend.get_csharpls_client()
     if client then
         local params
-        if vim.fn.has('nvim-0.11') then
+        if vim.fn.has('nvim-0.11') == 1 then
             params = vim.lsp.util.make_position_params(0, 'utf-8')
         else
             params = vim.lsp.util.make_position_params()


### PR DESCRIPTION
The error appears every time you try to go to a definition:
 ```
 Error executing vim.schedule lua callback: /usr/share/nvim/runtime/lua/vim/lsp/util.lua:1104: attempt to index local 'location' (a nil value)                                                                                         
stack traceback:                                                                                                                                                                                                                               
        /usr/share/nvim/runtime/lua/vim/lsp/util.lua:1104: in function 'show_document'                                                                                                                                                         
        ...art/csharpls-extended-lsp.nvim/lua/csharpls_extended.lua:173: in function 'handle_locations'                                                                                                                                        
        ...art/csharpls-extended-lsp.nvim/lua/csharpls_extended.lua:191: in function 'handler'                                                                                                                                                 
        /usr/share/nvim/runtime/lua/vim/lsp/client.lua:687: in function ''                                                                                                                                                                     
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

This is because the `has()` function returning 0 make it consider like "true" in the if statement.

Tested only with nvim 0.10.4